### PR TITLE
DATAGO-105494: Documetation update for the NodePorts

### DIFF
--- a/docs/EventBrokerOperatorUserGuide.md
+++ b/docs/EventBrokerOperatorUserGuide.md
@@ -486,7 +486,7 @@ kubectl get pods --show-labels
 
 To support [Internal load balancers](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer), a provider-specific service annotation can be added by defining the `spec.service.annotations` parameter.
 
-The `spec.service.ports` parameter defines the broker ports/services exposed. It specifies the event broker `containerPort` that provides the service and the mapping to the `servicePort` where the service can be accessed when using LoadBalancer or ClusterIP. By default most broker service ports are exposed, refer to the ["pubsubpluseventbrokers" Custom Resource definition](/config/crd/bases/pubsubplus.solace.com_pubsubpluseventbrokers.yaml).
+The `spec.service.ports` parameter defines the broker ports/services exposed. It specifies the event broker `containerPort` that provides the service and the mapping to the `servicePort` where the service can be accessed when using LoadBalancer or ClusterIP. By default, most broker service ports are exposed, refer to the ["pubsubpluseventbrokers" Custom Resource definition](/config/crd/bases/pubsubplus.solace.com_pubsubpluseventbrokers.yaml).
 
 Example:
 ```yaml
@@ -502,11 +502,11 @@ spec:
         name: tcp-smf
       - ...
 ```
-For `NodePort` service type, we have two configuration options:
+For the `NodePort` service type, we have two configuration options:
 
 **Option 1:** Explicit NodePort Assignment.
 
-With this option, you explicitly specify which node ports to use for each service port. This gives you full control over port assignments. However, if there are conflicts with existing NodePorts, the deployment will fail.
+Explicitly specify which node ports to use for each service port. This gives you full control over port assignments. However, if there are conflicts with existing NodePorts, the deployment will fail.
 
 ```yaml
 apiVersion: pubsubplus.solace.com/v1beta1
@@ -537,7 +537,7 @@ spec:
 
 **Option 2:** Automatic NodePort Assignment.
 
-With this option, you let Kubernetes automatically assign node ports. This is simpler but gives you less control. It also avoids conflicts with existing NodePorts, as Kubernetes will find available ports for you.
+Let Kubernetes automatically assign node ports. This is simpler but gives you less control. It also avoids conflicts with existing NodePorts, as Kubernetes will find available ports for you.
 
 ```yaml
 apiVersion: pubsubplus.solace.com/v1beta1


### PR DESCRIPTION
### JIRA
https://sol-jira.atlassian.net/browse/DATAGO-105494

### Description

Documentation updates to show the two main options for configuring the broker for NodePort service type. 

### Anything for reviewers to be aware of? 

N/A

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update NodePort configuration documentation in the Event Broker Operator User Guide to clarify port assignment options and control.

Main changes:
- Removed incorrect statement about lack of control over NodePort mappings
- Added detailed explanation of two NodePort configuration options with YAML examples
- Clarified explicit vs. automatic NodePort assignment methods with benefits and limitations

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
